### PR TITLE
Fix local demo import path

### DIFF
--- a/tools/app.py
+++ b/tools/app.py
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+from pathlib import Path
+
 import gradio as gr
 import torch
 from PIL import Image
 from diffusers.utils import load_image
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 # 导入你的两个 Pipeline
 from dreamlite import DreamLitePipeline 


### PR DESCRIPTION
Fixes #14.

	ools/app.py is documented as being run with python tools/app.py. In that mode Python puts the 	ools/ directory on sys.path, so the repository-root dreamlite/ package may not be importable.

This adds the repository root to sys.path before importing dreamlite, allowing the local Gradio demo to be launched from a fresh checkout using the documented command.